### PR TITLE
Add sl and faith to notnics

### DIFF
--- a/src/netcardmgr
+++ b/src/netcardmgr
@@ -40,7 +40,7 @@ wifiscards = wifinics.stdout.readlines()
 
 rcconf_out = open('/etc/rc.conf', 'r')
 rcconf = rcconf_out.readlines()
-notnics = ["wlan0", "lo0", "fwe", "fwip", "lo1", "plip", "pfsync", "pflog", "tun"]
+notnics = ["wlan0", "lo0", "fwe", "fwip", "lo1", "plip", "pfsync", "pflog", "tun", "sl", "faith"]
 
 
 class autoConfigure():


### PR DESCRIPTION
sl0 and faith0 are present in DragonFly BSD systems by default and they are not supposed to work like NICs so add them to notnics. I think this won't hurt any other BSD.

Also stuff like tap or bridge would need to be in notnics but for different reasons. In my opinion, what would be really needed is a configuration dialog.