### PR TITLE
Added function so that hovering mouse over networkmgr icon in mate taskbar shows dotted decimal subnet masks instead of hexadecimal.

### DIFF
--- a/networkmgr
+++ b/networkmgr
@@ -1,8 +1,9 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.7
 
 from sys import path
 import signal
-path.append("/usr/local/share/networkmgr")
+# path.append("/usr/local/share/networkmgr") Added this comment so I could run test code without calling prod code
+path.append("/usr/home/bcrouch/Projects/networkmgr/src")
 from trayicon import trayIcon
 
 signal.signal(signal.SIGINT, signal.SIG_DFL)

--- a/networkmgr
+++ b/networkmgr
@@ -2,8 +2,7 @@
 
 from sys import path
 import signal
-# path.append("/usr/local/share/networkmgr") Added this comment so I could run test code without calling prod code
-path.append("/usr/home/bcrouch/Projects/networkmgr/src")
+path.append("/usr/local/share/networkmgr")
 from trayicon import trayIcon
 
 signal.signal(signal.SIGINT, signal.SIG_DFL)

--- a/src/net_api.py
+++ b/src/net_api.py
@@ -282,7 +282,7 @@ def connectionStatus(card):
                          universal_newlines=True)
             line1 = out1.stdout.read().strip()
             line2 = out2.stdout.read().strip()
-            netstate = line1 + '\n' + line2
+            netstate = line1 + '\n' + subnetHexToDec(line2)
         else:
             netstate = "WiFi %s not conected" % card
     else:
@@ -290,7 +290,7 @@ def connectionStatus(card):
         out = Popen(cmd, shell=True, stdout=PIPE,
                     universal_newlines=True)
         line = out.stdout.read().strip()
-        netstate = line
+        netstate = subnetHexToDec(line)
     return netstate
 
 
@@ -360,3 +360,11 @@ def connectToSsid(name, wificard):
         sleep(2)
         os.system(f'doas dhclient {wificard}')
     sleep(0.5)
+
+def subnetHexToDec( ifconfigstring ):
+    snethex = re.search('0x.{8}', ifconfigstring).group(0)[2:]
+    snethexlist = re.findall('..', snethex)
+    snetdeclist = [int(li, 16) for li in snethexlist]
+    snetdec = ".".join(str(li) for li in snetdeclist)
+    outputline = ifconfigstring.replace(re.search('0x.{8}',ifconfigstring).group(0),snetdec)
+    return outputline

--- a/src/netcardmgr
+++ b/src/netcardmgr
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.7
 #
 # Copyright (c) 2013-2019, GhostBSD All rights reserved.
 #


### PR DESCRIPTION
Hi Eric.

I thought that it would look better if network manager showed the ip address, subnet mask, and broadcast address so that all of them were in dotted decimal format. Previously the subnet mask was in hexadecimal, while the ip address and broadcast address were dotted decimal. I know it's a minor cosmetic change, but I think it would make it easier for people that don't know networking to see it all as dotted decimal. That is how most of the world talks about network addressing anyway.

Before it looked like this ...
![Screenshot at 2020-01-10 23-53-36](https://user-images.githubusercontent.com/29417240/72199751-d3232c80-3405-11ea-98c4-b31e6ce17927.png)

After my changes it now looks like this ...
![Screenshot at 2020-01-10 23-55-54](https://user-images.githubusercontent.com/29417240/72199758-dfa78500-3405-11ea-8cfa-d509cf2115e8.png)

I also updated the networkmgr and netcardmgr to execute with python3.7 to match the version that are currently deployed on active GhostBSD machines.

Thanks for your time!