### PR TITLE
Fix issue handling VLAN configuration from rc.conf

### DIFF
--- a/src/netcardmgr
+++ b/src/netcardmgr
@@ -37,6 +37,9 @@ class autoConfigure():
     def __init__(self):
         for line in netcard.split():
             card = line.rstrip()
+	    # VLAN tags in ifconfig are delimited by period
+	    # but in rc.conf delimiter is underscore
+            card = card.replace(".", "_")
             nc = re.sub(r'\d+', '', line.rstrip())
             if nc not in notnics:
                 if f'ifconfig_{card}=' in rcconf:


### PR DESCRIPTION
One symptom of the issue is  in case of configured VLANs networkmgr generated the **rc.conf** entry 
>>ifconfig_igb0.3="DHCP" 

Then rc-service got confused parsing /etc/rc.conf content:  
>>ifconfig_igb0.3="DHCP"
>>[~]$ sudo service vboxnet status
/>>etc/rc.conf: ifconfig_igb0.3=DHCP: not found
 >>* vboxnet: error loading /etc/rc.conf
>>[~]$ sudo service dbus status
>>/etc/rc.conf: ifconfig_igb0.3=DHCP: not found
>> * dbus: error loading /etc/rc.conf"

I tested the patch by restarting networkmgr before and after reboot and checked the symptom didn't occur anymore