### PR TITLE
Adding ignore for pipenv and pycharm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,15 @@ pip-log.txt
 .tox
 nosetests.xml
 
+# Pipenv and lock files
+Pipfile
+Pipfile.lock
+venv/*
+
+# Pycharm stuff
+.idea/*
+
+
 # Translations
 *.mo
 

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ venv/*
 # Pycharm stuff
 .idea/*
 
+# VSCode
+.vscode/*
 
 # Translations
 *.mo


### PR DESCRIPTION
Update .gitignore file to ignore pipenv files, venv directories and PyCharm directories.