### PR TITLE
Add enc virtual device and ipfw logging interface as non interfaces

### DIFF
--- a/src/netcardmgr
+++ b/src/netcardmgr
@@ -16,6 +16,7 @@ wifiscard = wifinics.stdout.readlines()[0].rstrip()
 rcconf = open('/etc/rc.conf', 'r').read()
 
 notnics = [
+    "enc",
     "lo",
     "fwe",
     "fwip",
@@ -23,6 +24,7 @@ notnics = [
     "plip",
     "pfsync",
     "pflog",
+    "ipfw",
     "tun",
     "sl",
     "faith",


### PR DESCRIPTION
Add "enc" the virtual encapsulation device for IPSEC and "ipfw" the logging interface of the FreeBSD IPFW firewall as non interfaces.

