### PR TITLE
Add support to detect rc.conf.local configured devices

### DIFF
--- a/src/netcardmgr
+++ b/src/netcardmgr
@@ -14,6 +14,7 @@ wifinics = Popen(wifis, shell=True, stdout=PIPE, close_fds=True,
                  universal_newlines=True)
 wifiscard = wifinics.stdout.readlines()[0].rstrip()
 rcconf = open('/etc/rc.conf', 'r').read()
+rcconflocal = open('/etc/rc.conf.local', 'r').read()
 
 notnics = [
     "enc",
@@ -61,6 +62,8 @@ class autoConfigure():
             if nc not in notnics:
                 if f'ifconfig_{card}=' in rcconf:
                     print("Your wired network card is already configured.")
+                elif f'ifconfig_{card}=' in rcconflocal:
+                    print("Your wired network card is already configured.")
                 else:
                     rc = open('/etc/rc.conf', 'a')
                     rc.writelines(f'ifconfig_{card}="DHCP"\n')
@@ -75,9 +78,9 @@ class autoConfigure():
 
         for card in wifiscard.split():
             for wlanNum in range(0, 9):
-                if f'wlan{wlanNum}' not in rcconf:
+                if f'wlan{wlanNum}' not in rcconf and not in rcconflocal:
                     break
-            if f'wlans_{card}=' in rcconf:
+            if f'wlans_{card}=' in rcconf or in rcconflocal:
                 print("Your wifi network card is already configured.")
                 if not os.path.exists('/etc/wpa_supplicant.conf'):
                     open('/etc/wpa_supplicant.conf', 'a').close()


### PR DESCRIPTION
This is a WIP to also detect configured interfaces in rc.conf.local. If our interfaces are not present in either we still standardly write to rc.conf.