### PR TITLE
Fix logic error.

### DIFF
--- a/src/netcardmgr
+++ b/src/netcardmgr
@@ -79,9 +79,9 @@ class autoConfigure():
 
         for card in wifiscard.split():
             for wlanNum in range(0, 9):
-                if f'wlan{wlanNum}' not in (rcconf and rcconflocal):
+                if f'wlan{wlanNum}' not in (rcconf + rcconflocal):
                     break
-            if f'wlans_{card}=' in (rcconf or rcconflocal):
+            if f'wlans_{card}=' in (rcconf + rcconflocal):
                 print("Your wifi network card is already configured.")
                 if not os.path.exists('/etc/wpa_supplicant.conf'):
                     open('/etc/wpa_supplicant.conf', 'a').close()


### PR DESCRIPTION
`if f'wlan{wlanNum}' not in (rcconf and rcconflocal):`

Assuming rcconf is not None, only rcconflocal is checked if it contains
wlan{wlanNum}. Concatenate lists with + to check both.

`if f'wlans_{card}=' in (rcconf or rcconflocal):`

Only rcconf is checked if it's not None. Concatenate lists with + to
check both.