### PR TITLE
Allow networkmgr to run without installation to /usr/local/share/

### DIFF
--- a/networkmgr
+++ b/networkmgr
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3.7
 
+from os.path import dirname
 from sys import path
 import signal
 path.append("/usr/local/share/networkmgr")
+path.append(dirname(__file__) + "/src")
 from trayicon import trayIcon
 
 signal.signal(signal.SIGINT, signal.SIG_DFL)


### PR DESCRIPTION
This is useful e.g., for running `git pull` and then `./networkmgr`