### PR TITLE
Unit tests for net_api.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+attrs==21.2.0
+coverage==6.2
+iniconfig==1.1.1
+packaging==21.3
+pluggy==1.0.0
+py==1.11.0
+pyparsing==3.0.6
+pytest==6.2.5
+pytest-cov==3.0.0
+Tkinter==0.0.0
+toml==0.10.2
+tomli==2.0.0

--- a/src/net_api.py
+++ b/src/net_api.py
@@ -223,7 +223,7 @@ def connectionStatus(card):
             line2 = out2.stdout.read().strip()
             netstate = line1 + '\n' + subnetHexToDec(line2)
         else:
-            netstate = "WiFi %s not conected" % card
+            netstate = "WiFi %s not connected" % card
     else:
         cmd = "ifconfig %s | grep 'inet '" % card
         out = Popen(cmd, shell=True, stdout=PIPE,

--- a/tests/README.md
+++ b/tests/README.md
@@ -63,7 +63,7 @@ unit/test_net_api.py::test_connection_status_card_is_wlan_connected PASSED      
 -------- coverage: platform freebsd13, python 3.8.12-final-0 ---------
 Name                                                                Stmts   Miss  Cover
 ---------------------------------------------------------------------------------------
-/usr/home/rgeorgia/PycharmProjects/networkmgr-fork/src/net_api.py     199    119    40%
+/usr/home/<your project>/networkmgr-fork/src/net_api.py     199    119    40%
 ---------------------------------------------------------------------------------------
 TOTAL                                                                 199    119    40%
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,74 @@
+# Testing networkmgr modules
+
+Testing networkmgr modules with pytest
+
+1. Create a virtual environment using python 3.8
+2. Activate the venv
+3. Install pytest and pytest coverage
+4. Execute pip list to verify your environment.
+
+```bash
+python3.8 -m venv venv38
+
+source venv38/bin/activate
+
+pip install pytest pytest-cov
+
+networkmgr-fork/tests on  unit_tests [!?] via 🐍 v3.8.12 (venv38) 
+❯ pip list
+Package    Version
+---------- -------
+attrs      21.2.0
+coverage   6.2
+iniconfig  1.1.1
+packaging  21.3
+pip        21.3.1
+pluggy     1.0.0
+py         1.11.0
+pyparsing  3.0.6
+pytest     6.2.5
+pytest-cov 3.0.0
+setuptools 60.1.0
+sqlite3    0.0.0
+Tkinter    0.0.0
+toml       0.10.2
+tomli      2.0.0
+```
+
+To run the tests navigate to the tests directory and enter the following command,
+
+```bash
+pytest -lv --cov src  unit/
+```
+
+The result will be similar to this, 
+
+```bash
+❯ pytest -lv --cov src  unit/
+================================================== test session starts ===================================================
+platform freebsd13 -- Python 3.8.12, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- /usr/home/<your project>/venv38/bin/python3.8
+cachedir: .pytest_cache
+rootdir: /usr/home/rgeorgia/PycharmProjects/networkmgr-fork
+plugins: cov-3.0.0
+collected 7 items                                                                                                        
+
+unit/test_net_api.py::test_default_card_returns_str PASSED                                                         [ 14%]
+unit/test_net_api.py::test_card_online PASSED                                                                      [ 28%]
+unit/test_net_api.py::test_card_not_online PASSED                                                                  [ 42%]
+unit/test_net_api.py::test_connection_status_card_is_none PASSED                                                   [ 57%]
+unit/test_net_api.py::test_connection_status_card_is_default PASSED                                                [ 71%]
+unit/test_net_api.py::test_connection_status_card_is_wlan_not_connected PASSED                                     [ 85%]
+unit/test_net_api.py::test_connection_status_card_is_wlan_connected PASSED                                         [100%]
+
+-------- coverage: platform freebsd13, python 3.8.12-final-0 ---------
+Name                                                                Stmts   Miss  Cover
+---------------------------------------------------------------------------------------
+/usr/home/rgeorgia/PycharmProjects/networkmgr-fork/src/net_api.py     199    119    40%
+---------------------------------------------------------------------------------------
+TOTAL                                                                 199    119    40%
+
+
+=================================================== 7 passed in 0.11s ====================================================
+
+
+```

--- a/tests/unit/test_net_api.py
+++ b/tests/unit/test_net_api.py
@@ -73,6 +73,7 @@ def test_connection_status_card_is_none():
     card = None
     result = connectionStatus(card)
     assert isinstance(result, str)
+    assert "Network card is not enabled" == result
 
 
 def test_connection_status_card_is_default():

--- a/tests/unit/test_net_api.py
+++ b/tests/unit/test_net_api.py
@@ -65,3 +65,25 @@ def test_card_not_online():
     netcard = "em99"
     result = card_online(netcard)
     assert not result
+
+
+def test_connectionStatus_card_is_none():
+    card = None
+    result = connectionStatus(card)
+    assert isinstance(result, str)
+
+
+def test_connectionStatus_card_is_default():
+    card = defaultcard()
+    result = connectionStatus(card)
+    assert isinstance(result, str)
+    assert "inet" in result
+    assert "netmask" in result
+    assert "broadcast" in result
+
+
+def test_connectionStatus_card_is_wlan_not_connected():
+    card = 'wlan00'
+    result = connectionStatus(card)
+    assert isinstance(result, str)
+    assert f"WiFi {card} not connected"

--- a/tests/unit/test_net_api.py
+++ b/tests/unit/test_net_api.py
@@ -1,0 +1,57 @@
+import sys
+from pathlib import Path
+
+top_dir = str(Path(__file__).absolute().parent.parent.parent)
+
+try:
+    from src.net_api import (
+        stopnetworkcard,
+        startnetworkcard,
+        wifiDisconnection,
+        stopallnetwork,
+        startallnetwork,
+        connectToSsid,
+        disableWifi,
+        enableWifi,
+        connectionStatus,
+        networkdictionary,
+        openrc,
+        delete_ssid_wpa_supplicant_config,
+        wlan_status,
+        card_online,
+        defaultcard
+    )
+except ImportError:
+    sys.path.append(top_dir)
+    from src.net_api import (
+        stopnetworkcard,
+        startnetworkcard,
+        wifiDisconnection,
+        stopallnetwork,
+        startallnetwork,
+        connectToSsid,
+        disableWifi,
+        enableWifi,
+        connectionStatus,
+        networkdictionary,
+        openrc,
+        delete_ssid_wpa_supplicant_config,
+        wlan_status,
+        card_online,
+        defaultcard
+    )
+
+
+def test_defaultcard_returns_str():
+    result = defaultcard()
+    assert isinstance(result, str)
+
+def test_card_online():
+    netcard = defaultcard()
+    result = card_online(netcard)
+    assert result
+
+def test_card_not_online():
+    netcard = "em99"
+    result = card_online(netcard)
+    assert not result

--- a/tests/unit/test_net_api.py
+++ b/tests/unit/test_net_api.py
@@ -5,40 +5,40 @@ top_dir = str(Path(__file__).absolute().parent.parent.parent)
 
 try:
     from src.net_api import (
-        stopnetworkcard,
-        startnetworkcard,
-        wifiDisconnection,
-        stopallnetwork,
-        startallnetwork,
+        card_online,
+        connectionStatus,
         connectToSsid,
+        defaultcard,
+        delete_ssid_wpa_supplicant_config,
         disableWifi,
         enableWifi,
-        connectionStatus,
         networkdictionary,
         openrc,
-        delete_ssid_wpa_supplicant_config,
+        startallnetwork,
+        startnetworkcard,
+        stopallnetwork,
+        stopnetworkcard,
+        wifiDisconnection,
         wlan_status,
-        card_online,
-        defaultcard
     )
 except ImportError:
     sys.path.append(top_dir)
     from src.net_api import (
-        stopnetworkcard,
-        startnetworkcard,
-        wifiDisconnection,
-        stopallnetwork,
-        startallnetwork,
+        card_online,
+        connectionStatus,
         connectToSsid,
+        defaultcard,
+        delete_ssid_wpa_supplicant_config,
         disableWifi,
         enableWifi,
-        connectionStatus,
         networkdictionary,
         openrc,
-        delete_ssid_wpa_supplicant_config,
+        startallnetwork,
+        startnetworkcard,
+        stopallnetwork,
+        stopnetworkcard,
+        wifiDisconnection,
         wlan_status,
-        card_online,
-        defaultcard
     )
 
 
@@ -46,10 +46,12 @@ def test_defaultcard_returns_str():
     result = defaultcard()
     assert isinstance(result, str)
 
+
 def test_card_online():
     netcard = defaultcard()
     result = card_online(netcard)
     assert result
+
 
 def test_card_not_online():
     netcard = "em99"

--- a/tests/unit/test_net_api.py
+++ b/tests/unit/test_net_api.py
@@ -48,7 +48,8 @@ except ImportError:
     import src.net_api
 
 
-def test_defaultcard_returns_str():
+def test_default_card_returns_str():
+    """test for src.net_api.defaultcard"""
     result = defaultcard()
     assert isinstance(result, str)
 
@@ -56,24 +57,26 @@ def test_defaultcard_returns_str():
 # TODO: mock subprocess to return empty list
 
 def test_card_online():
-    netcard = defaultcard()
-    result = card_online(netcard)
+    net_card = defaultcard()
+    result = card_online(net_card)
     assert result
 
 
 def test_card_not_online():
-    netcard = "em99"
-    result = card_online(netcard)
+    net_card = "em99"
+    result = card_online(net_card)
     assert not result
 
 
-def test_connectionStatus_card_is_none():
+def test_connection_status_card_is_none():
+    """test for src.net_api.connectionStatus"""
     card = None
     result = connectionStatus(card)
     assert isinstance(result, str)
 
 
-def test_connectionStatus_card_is_default():
+def test_connection_status_card_is_default():
+    """test for src.net_api.connectionStatus"""
     card = defaultcard()
     result = connectionStatus(card)
     assert isinstance(result, str)
@@ -82,14 +85,16 @@ def test_connectionStatus_card_is_default():
     assert "broadcast" in result
 
 
-def test_connectionStatus_card_is_wlan_not_connected():
+def test_connection_status_card_is_wlan_not_connected():
+    """test for src.net_api.connectionStatus"""
     card = 'wlan99'
     result = connectionStatus(card)
     assert isinstance(result, str)
     assert f"WiFi {card} not connected" in result
 
 
-def test_connectionStatus_card_is_wlan_connected():
+def test_connection_status_card_is_wlan_connected():
+    """test for src.net_api.connectionStatus"""
     card = 'wlan0'
     result = connectionStatus(card)
     assert isinstance(result, str)

--- a/tests/unit/test_net_api.py
+++ b/tests/unit/test_net_api.py
@@ -87,3 +87,13 @@ def test_connectionStatus_card_is_wlan_not_connected():
     result = connectionStatus(card)
     assert isinstance(result, str)
     assert f"WiFi {card} not connected"
+
+
+def test_connectionStatus_card_is_wlan_connected():
+    card = 'wlan0'
+    result = connectionStatus(card)
+    assert isinstance(result, str)
+    assert "inet" in result
+    assert "ssid" in result
+    assert "netmask" in result
+    assert "broadcast" in result

--- a/tests/unit/test_net_api.py
+++ b/tests/unit/test_net_api.py
@@ -86,7 +86,7 @@ def test_connectionStatus_card_is_wlan_not_connected():
     card = 'wlan99'
     result = connectionStatus(card)
     assert isinstance(result, str)
-    assert f"WiFi {card} not connected"
+    assert f"WiFi {card} not connected" in result
 
 
 def test_connectionStatus_card_is_wlan_connected():

--- a/tests/unit/test_net_api.py
+++ b/tests/unit/test_net_api.py
@@ -1,5 +1,9 @@
 import sys
 from pathlib import Path
+from subprocess import Popen
+import subprocess
+
+import pytest
 
 top_dir = str(Path(__file__).absolute().parent.parent.parent)
 
@@ -21,6 +25,7 @@ try:
         wifiDisconnection,
         wlan_status,
     )
+    import src.net_api
 except ImportError:
     sys.path.append(top_dir)
     from src.net_api import (
@@ -40,12 +45,15 @@ except ImportError:
         wifiDisconnection,
         wlan_status,
     )
+    import src.net_api
 
 
 def test_defaultcard_returns_str():
     result = defaultcard()
     assert isinstance(result, str)
 
+
+# TODO: mock subprocess to return empty list
 
 def test_card_online():
     netcard = defaultcard()

--- a/tests/unit/test_net_api.py
+++ b/tests/unit/test_net_api.py
@@ -83,7 +83,7 @@ def test_connectionStatus_card_is_default():
 
 
 def test_connectionStatus_card_is_wlan_not_connected():
-    card = 'wlan00'
+    card = 'wlan99'
     result = connectionStatus(card)
     assert isinstance(result, str)
     assert f"WiFi {card} not connected"


### PR DESCRIPTION
Unit tests for net_api.py. Tests for only the following methods:
- card_online
- connectionStatus
- defaultcard

NOTE: Unable to force defaultcard() to return None.