### PR TITLE
fix no signal level from the card

### DIFF
--- a/networkmgr
+++ b/networkmgr
@@ -3,7 +3,7 @@
 from os.path import dirname
 from sys import path
 import signal
-path.append("/usr/local/share/networkmgr")
+#path.append("/usr/local/share/networkmgr")
 path.append(dirname(__file__) + "/src")
 from trayicon import trayIcon
 

--- a/networkmgr
+++ b/networkmgr
@@ -3,7 +3,7 @@
 from os.path import dirname
 from sys import path
 import signal
-#path.append("/usr/local/share/networkmgr")
+path.append("/usr/local/share/networkmgr")
 path.append(dirname(__file__) + "/src")
 from trayicon import trayIcon
 


### PR DESCRIPTION
Hi:

I'm requesting a pull to fix an issue when the card doesn't respond with the signal level. This issues produces that the tray icon always appears as no signal. 

An example of answer of my card:

```
SSID/MESH ID                      BSSID              CHAN RATE    S:N     INT CAPS
aaa                         18:3c:b7:e3:83:d8    1   54M  -84:-96   100 EPS  RSN WME BSSLOAD HTCAP VHTCAP VHTOPMODE WPS
bbb                       78:81:02:60:c7:85  108   54M  -96:-96   100 EP   BSSLOAD VHTPWRENV HTCAP WME RSN WPS VHTCAP VHTOPMODE
```

In the example the ssid=bbb is the ssid my laptop is attached, and always the S:N is -96:-96, ... always. I've seen similar behaviors in the internet. To overcome this issue people use to launch the following command to obtain the level:

```
ifconfig wlan1 list sta

ADDR               AID CHAN RATE RSSI IDLE  TXSEQ  RXSEQ CAPS FLAG        
78:81:02:60:c7:85   66  108  54M 63.0    0   5084  61664 EP   AQU          BSSLOAD VHTPWRENV HTCAP WME RSN WPS VHTCAP VHTOPMODE (rssi 0.0:0.0:0.0:0.0 nf 0:0:0:0)

```
And the output shows the RSSI level. 

The fix I put into the code consists of executing this command, and when the variable 'percentage' is 0 for the connected ssi, then replace it for the percentage calculated with the RSSI level.

This fix the issue. The code maybe could be cleaner... and it's not heavy tested... 

There is something that is not clear to me. To convert from RSSI dBms to percentage I've used this formula:

percentage=quality=2 * ((RSSI * -1) + 100)

But in my case what I obtain is 74% despite of my laptop is just front the router, and because of that the reception is optimal. In the code I've change the formula for this one:

qual=2 * ((RSSI * -1) + 113)

After reading some document in the internet... but I'm not 100% sure.

Thanks for you master piece networkmgr that help all of use using freebsd/ghostbsd/... a lot.

BR,

Jes

