### PR TITLE
src: auto-switch: use `kenv -q` instead of `kenv`

### DIFF
--- a/src/auto-switch.py
+++ b/src/auto-switch.py
@@ -10,7 +10,7 @@ if len(args) != 2:
     exit()
 nic = args[1]
 
-cmd = ["kenv", "rc_system"]
+cmd = ["kenv", "-q", "rc_system"]
 rc_system = Popen(cmd, stdout=PIPE, universal_newlines=True).stdout.read()
 openrc = True if 'openrc' in rc_system else False
 


### PR DESCRIPTION
This suppresses the "unable to get rc_system" message that one would see if rc_system wasn't set in the kenv.  There's no reason we should be visibly complaining to the user about this, as the var missing isn't necessarily unexpected (e.g., on stock FreeBSD).

Other kenv use LGTM; just this one that needs touched up.

This should fix https://www.reddit.com/r/freebsd/comments/14mmfyl/freebsd_14_kenv_error/