### PR TITLE
Update README.md python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ See https://www.freshports.org/net-mgmt/networkmgr/#add for instructions on inst
 
 Packages that have to be installed before installing NetworkMgr:
 
-`pkg install sudo py38-setuptools py38-gobject3 gtk-update-icon-cache hicolor-icon-theme`
+`pkg install sudo py311-setuptools py311-gobject3 gtk-update-icon-cache hicolor-icon-theme`
 
 If NetworkMgr was previously installed using a package, remove it:  
 


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the README.md file to specify the new required Python version (3.11) for installing NetworkMgr, replacing the previous version (3.8).

- **Documentation**:
    - Updated the README.md to reflect the change in the required Python version from 3.8 to 3.11 for installing NetworkMgr.

<!-- Generated by sourcery-ai[bot]: end summary -->