### PR TITLE
Add IPv6 configuration support

### DIFF
--- a/NetworkMgr/net_api.py
+++ b/NetworkMgr/net_api.py
@@ -327,8 +327,9 @@ def start_static_ipv6_network(netcard, inet6, prefixlen):
 
 
 def enable_slaac(netcard):
-    """Enable SLAAC (Stateless Address Autoconfiguration) on the interface."""
-    # Remove any existing IPv6 addresses first
+    """Enable SLAAC (Stateless Address Autoconfiguration) on the interface
+    by toggling accept_rtadv and soliciting router advertisements."""
+    # First disable, then re-enable to ensure clean state
     run(f'ifconfig {netcard} inet6 -accept_rtadv', shell=True)
     sleep(0.5)
     # Enable accept_rtadv for SLAAC
@@ -343,10 +344,11 @@ def disable_slaac(netcard):
 
 
 def get_ipv6_addresses(netcard):
-    """Get all IPv6 addresses configured on the interface."""
+    """Get all IPv6 addresses configured on the interface.
+    Returns list of tuples: (address, prefixlen)."""
     try:
         output = check_output(f'ifconfig {netcard}', shell=True, universal_newlines=True)
-        # Match inet6 addresses, excluding link-local (fe80::) and localhost (::1)
+        # Match all inet6 addresses with their prefix lengths
         addresses = re.findall(r'inet6 ([0-9a-fA-F:]+)%?\S* prefixlen (\d+)', output)
         return [(addr, int(prefixlen)) for addr, prefixlen in addresses]
     except Exception:

--- a/NetworkMgr/query.py
+++ b/NetworkMgr/query.py
@@ -57,7 +57,7 @@ def get_interface_settings_ipv6(active_nic):
     # Get IPv6 default gateway from rc.conf or routing table
     # Pattern allows optional interface suffix for link-local (e.g., fe80::1%em0)
     gateway_search = re.search(
-        r'^ipv6_defaultrouter="([0-9a-fA-F:%]+)"',
+        r'^ipv6_defaultrouter="([0-9a-fA-F:]+(?:%[a-zA-Z0-9]+)?)"',
         rc_conf,
         re.MULTILINE
     )

--- a/NetworkMgr/query.py
+++ b/NetworkMgr/query.py
@@ -55,8 +55,9 @@ def get_interface_settings_ipv6(active_nic):
         ipv6_settings["Prefix Length"] = "64"
 
     # Get IPv6 default gateway from rc.conf or routing table
+    # Pattern allows optional interface suffix for link-local (e.g., fe80::1%em0)
     gateway_search = re.search(
-        r'^ipv6_defaultrouter="([0-9a-fA-F:]+)"',
+        r'^ipv6_defaultrouter="([0-9a-fA-F:%]+)"',
         rc_conf,
         re.MULTILINE
     )

--- a/NetworkMgr/query.py
+++ b/NetworkMgr/query.py
@@ -5,6 +5,111 @@ import re
 import os
 
 
+def get_interface_settings_ipv6(active_nic):
+    """Get IPv6 settings for the given network interface."""
+    ipv6_settings = {}
+    rc_conf = open("/etc/rc.conf", "r").read()
+
+    # Check if SLAAC is enabled (accept_rtadv in rc.conf)
+    slaac_search = re.search(
+        fr'^ifconfig_{active_nic}_ipv6=".*accept_rtadv',
+        rc_conf,
+        re.MULTILINE | re.IGNORECASE
+    )
+    if slaac_search:
+        ipv6_settings["Assignment Method"] = "SLAAC"
+    else:
+        # Check for static IPv6 configuration
+        static_search = re.search(
+            fr'^ifconfig_{active_nic}_ipv6="inet6\s+([0-9a-fA-F:]+).*prefixlen\s+(\d+)',
+            rc_conf,
+            re.MULTILINE
+        )
+        if static_search:
+            ipv6_settings["Assignment Method"] = "Manual"
+        else:
+            ipv6_settings["Assignment Method"] = "SLAAC"  # Default
+
+    # Get current IPv6 address from ifconfig
+    try:
+        ifcmd = f"ifconfig {active_nic}"
+        ifoutput = check_output(ifcmd.split(" "), universal_newlines=True)
+
+        # Find global IPv6 addresses (exclude link-local fe80::)
+        ipv6_matches = re.findall(
+            r'inet6 ([0-9a-fA-F:]+)%?\S* prefixlen (\d+)',
+            ifoutput
+        )
+        # Filter out link-local addresses
+        global_addrs = [(addr, plen) for addr, plen in ipv6_matches
+                        if not addr.lower().startswith('fe80:')]
+
+        if global_addrs:
+            ipv6_settings["Interface IPv6"] = global_addrs[0][0]
+            ipv6_settings["Prefix Length"] = global_addrs[0][1]
+        else:
+            ipv6_settings["Interface IPv6"] = ""
+            ipv6_settings["Prefix Length"] = "64"
+    except Exception:
+        ipv6_settings["Interface IPv6"] = ""
+        ipv6_settings["Prefix Length"] = "64"
+
+    # Get IPv6 default gateway from rc.conf or routing table
+    gateway_search = re.search(
+        r'^ipv6_defaultrouter="([0-9a-fA-F:]+)"',
+        rc_conf,
+        re.MULTILINE
+    )
+    if gateway_search:
+        ipv6_settings["Default Gateway"] = gateway_search.group(1)
+    else:
+        # Try to get from routing table
+        try:
+            netstat_output = check_output(
+                'netstat -rn -f inet6'.split(),
+                universal_newlines=True
+            )
+            for line in netstat_output.splitlines():
+                if line.startswith('default'):
+                    parts = line.split()
+                    if len(parts) >= 2:
+                        # Remove interface suffix if present (e.g., fe80::1%em0)
+                        gw = parts[1].split('%')[0]
+                        ipv6_settings["Default Gateway"] = gw
+                        break
+            else:
+                ipv6_settings["Default Gateway"] = ""
+        except Exception:
+            ipv6_settings["Default Gateway"] = ""
+
+    # Get IPv6 DNS servers from resolv.conf
+    ipv6_settings["DNS Server 1"] = ""
+    if os.path.exists('/etc/resolv.conf'):
+        resolv_conf = open('/etc/resolv.conf').read()
+        # Match IPv6 nameservers (must contain at least one colon)
+        ipv6_nameservers = re.findall(
+            r'^nameserver\s+([0-9a-fA-F]*:[0-9a-fA-F:]+)',
+            resolv_conf,
+            re.MULTILINE
+        )
+        if ipv6_nameservers:
+            ipv6_settings["DNS Server 1"] = ipv6_nameservers[0]
+
+    # Get search domain (shared with IPv4)
+    ipv6_settings["Search Domain"] = ""
+    if os.path.exists('/etc/resolv.conf'):
+        resolv_conf = open('/etc/resolv.conf').read()
+        search_match = re.search(r'^search\s+(.+)$', resolv_conf, re.MULTILINE)
+        if search_match:
+            ipv6_settings["Search Domain"] = search_match.group(1).strip()
+        else:
+            domain_match = re.search(r'^domain\s+(.+)$', resolv_conf, re.MULTILINE)
+            if domain_match:
+                ipv6_settings["Search Domain"] = domain_match.group(1).strip()
+
+    return ipv6_settings
+
+
 def get_interface_settings(active_nic):
     interface_settings = {}
     rc_conf = open("/etc/rc.conf", "r").read()


### PR DESCRIPTION
## Summary

- Implement IPv6 support in the Network Configuration dialog
- Enable the previously disabled "IPv6 Settings WIP" tab
- Support both SLAAC and static IPv6 configuration

## Changes

### New Features
- **SLAAC**: Automatic IPv6 configuration via Router Advertisements
- **Static IPv6**: Manual address, prefix length, gateway, and DNS configuration
- **Link-local gateway support**: Automatically adds interface suffix for fe80:: addresses

### Bug Fixes
- Fix "IPv4 Method" label → "IPv6 Method"
- Fix "Subnet Mask" label → "Prefix Length"
- Fix duplicate `connect()` handler on wrong widget
- Fix `remove_rc_conf_line()` ValueError when line doesn't exist
- Fix `edit_ipv6_setting()` AttributeError during initialization
- Fix IPv6 DNS regex matching IPv4 addresses

### New Functions

**net_api.py:**
- `start_static_ipv6_network(netcard, inet6, prefixlen)`
- `enable_slaac(netcard)` / `disable_slaac(netcard)`
- `get_ipv6_addresses(netcard)`
- `has_slaac_enabled(netcard)`
- `get_ipv6_gateway()`

**query.py:**
- `get_interface_settings_ipv6(active_nic)`

## Test Plan

Tested on GhostBSD 14.3-RELEASE with FritzBox router:

- [x] Static IPv6 address configuration
- [x] SLAAC (receives global + ULA addresses)
- [x] IPv6 gateway with link-local address (fe80::)
- [x] IPv6 DNS server configuration
- [x] Persistence after reboot
- [x] Interface switching in GUI

## Screenshots

The IPv6 Settings tab is now functional with SLAAC/Manual radio buttons and input fields for Address, Prefix Length, Gateway, DNS, and Search Domain.

Closes #120

## Summary by Sourcery

Add functional IPv6 configuration support to the network manager, including SLAAC and static setup in the GUI and backend helpers.

New Features:
- Expose a fully functional IPv6 Settings tab with SLAAC and manual configuration options tied to per-interface state.
- Introduce backend helpers to configure static IPv6 addresses, control SLAAC, and query IPv6 addresses and gateway information.
- Provide IPv6-specific interface querying to populate the UI from rc.conf, ifconfig, routing table, and resolv.conf.

Bug Fixes:
- Correct IPv6-related labels and widget signal wiring in the configuration dialog.
- Prevent crashes when editing IPv6 settings during initialization or when rc.conf lines are missing.
- Tighten DNS parsing to only treat IPv6-style entries as IPv6 DNS servers.

Enhancements:
- Ensure IPv6 GUI controls reflect and update current interface assignment method and field sensitivity.
- Safely manage rc.conf variables and resolv.conf updates when toggling between manual IPv6 and SLAAC modes.