### PR TITLE
Improve devd scripts and bump version to 6.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from DistUtilsExtra.command.build_extra import build_extra
 from DistUtilsExtra.command.build_i18n import build_i18n
 from DistUtilsExtra.command.clean_i18n import clean_i18n
 
-__VERSION__ = '6.7'
+__VERSION__ = '6.8'
 PROGRAM_VERSION = __VERSION__
 
 prefix = '/usr/local' if system() == 'FreeBSD' else sys.prefix

--- a/src/link-up.py
+++ b/src/link-up.py
@@ -3,7 +3,7 @@
 import os
 import re
 import sys
-from subprocess import run
+from subprocess import run, PIPE
 
 args = sys.argv
 if len(args) != 2:
@@ -21,7 +21,7 @@ if re.search(not_nics_regex, nic):
 if os.path.exists(f'/tmp/link-down-{nic}'):
     nic_ifconfig = run(
         ['ifconfig', nic],
-        close_fds=True,
+        stdout=PIPE,
         universal_newlines=True
     ).stdout
 

--- a/src/link-up.py
+++ b/src/link-up.py
@@ -3,56 +3,34 @@
 import os
 import re
 import sys
-from subprocess import Popen, PIPE, run
+from subprocess import run
 
 args = sys.argv
 if len(args) != 2:
     exit(1)
 nic = args[1]
 
-not_nics_regex = "(enc|lo|fwe|fwip|tap|plip|pfsync|pflog|ipfw|tun|sl|faith|" \
-    "ppp|bridge|wg|wlan)[0-9]+|vm-[a-z]+"
+not_nics_regex = r"(enc|lo|fwe|fwip|tap|plip|pfsync|pflog|ipfw|tun|sl|faith|" \
+    r"ppp|bridge|wg|wlan)[0-9]+|vm-[a-z]+"
 
 # Stop the script if the nic is not valid.
 if re.search(not_nics_regex, nic):
     exit(0)
 
-dhcp = Popen(
-    ['sysrc', '-n', f'ifconfig_{nic}'],
-    stdout=PIPE,
-    close_fds=True,
-    universal_newlines=True
-).stdout.read()
+# This marker file is created by auto-switch.py when the nic is down.
+if os.path.exists(f'/tmp/link-down-{nic}'):
+    nic_ifconfig = run(
+        ['ifconfig', nic],
+        close_fds=True,
+        universal_newlines=True
+    ).stdout
 
-if os.path.exists(f'/tmp/network-{nic}'):
-    network = open(f'/tmp/network-{nic}', 'r').read()
-    if 'attached' in network:
-        if dhcp.strip() == 'DHCP':
-            Popen(f'service dhclient quietstart {nic}', shell=True)
-        else:
-            Popen(f'service routing restart', shell=True)
-        with open(f'/tmp/network-{nic}', 'w') as network:
-            network.writelines(f'linked')
-        exit(0)
+    if 'inet ' not in nic_ifconfig:
+        run(['service', 'netif', 'start', nic])
 
-nic_ifconfig = Popen(
-    ['ifconfig', nic],
-    stdout=PIPE,
-    close_fds=True,
-    universal_newlines=True
-).stdout.read()
-
-if 'inet ' in nic_ifconfig:
-    Popen(
-        f'service routing restart ; '
-        f'service dhclient restart {nic}',
-        shell=True
-    )
+    run(['service', 'routing', 'restart'])
+    run(['service', 'dhclient', 'restart', nic])
+    # Clean up marker file
+    os.remove(f'/tmp/link-down-{nic}')
 else:
-    Popen(
-        f'service netif start {nic} ; '
-        'sleep 1 ; '
-        f'service routing restart ; '
-        f'service dhclient restart {nic}',
-        shell=True
-    )
+    run(['service', 'dhclient', 'quietstart', nic])

--- a/src/networkmgr.conf
+++ b/src/networkmgr.conf
@@ -1,26 +1,26 @@
 
-notify 100 {
+notify 5 {
 	match "system"		"IFNET";
 	match "subsystem"	"!(usbus|wlan)[0-9]+";
 	match "type"		"ATTACH";
 	action "/usr/local/share/networkmgr/setup-nic.py $subsystem";
 };
 
-notify 100 {
+notify 5 {
 	match "system"		"IFNET";
 	match "type"		"LINK_UP";
 	media-type		"ethernet";
 	action "/usr/local/share/networkmgr/link-up.py $subsystem";
 };
 
-notify 100 {
+notify 5 {
 	match "system"		"IFNET";
 	match "subsystem"	"!(usbus|wlan)[0-9]+";
 	match "type"		"LINK_DOWN";
 	action "/usr/local/share/networkmgr/auto-switch.py $subsystem";
 };
 
-attach 100 {
+attach 5 {
 	device-name "$wifi-driver-regex";
 	action "/usr/local/share/networkmgr/setup-nic.py $device-name";
 };


### PR DESCRIPTION
- Replace Popen with subprocess.run() for cleaner code and better resource handling across all devd scripts
- Use proper raw string prefix (r"") for regex patterns
- Remove deprecated close_fds parameter (default True in Python 3)
- Change devd priority from 100 to 5 for faster event handling

auto-switch.py:
- Create marker file /tmp/link-down-{nic} for coordination with link-up.py
- Replace os.system() calls with subprocess.run()

link-up.py:
- Simplify logic using marker file from auto-switch.py
- Remove complex /tmp/network-{nic} state tracking
- Use explicit service calls instead of shell command strings

setup-nic.py:
- Use sysrc command instead of manual rc.conf file writing
- Fix wlan configuration logic to check wlans_{nic} only once
- Use appropriate pccard_ether action (startchildren for WiFi, start forEthernet)

## Summary by Sourcery

Streamline devd-based NIC management scripts for link up/down handling and configuration, and bump the application version.

New Features:
- Coordinate link-down and link-up handling using a temporary marker file to distinguish runtime link events from boot state.

Bug Fixes:
- Correct regular expressions used to filter network interfaces and detect inet addresses in devd scripts.

Enhancements:
- Simplify link-up handling logic to use explicit service calls and conditional netif restart instead of ad-hoc state files and shell command strings.
- Refactor auto-switch and setup-nic scripts to use subprocess.run and sysrc for safer, more maintainable system interaction and configuration updates.
- Adjust devd notification priority to a lower value for faster processing of network interface events.

Chores:
- Bump the project version from 6.7 to 6.8.