### PR TITLE
Fix for using translation files in case-sensitive file systems

### DIFF
--- a/NetworkMgr/trayicon.py
+++ b/NetworkMgr/trayicon.py
@@ -40,8 +40,8 @@ from NetworkMgr.wg_api import (
     wg_status
 )
 
-gettext.bindtextdomain('networkmgr', '/usr/local/share/locale')
-gettext.textdomain('networkmgr')
+gettext.bindtextdomain('NetworkMgr', '/usr/local/share/locale')
+gettext.textdomain('NetworkMgr')
 _ = gettext.gettext
 
 encoding = locale.getpreferredencoding()


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix translation loading on case-sensitive file systems by matching the gettext domain to the application name.